### PR TITLE
Fix scalafmt formatting for Config.scala

### DIFF
--- a/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/Config.scala
+++ b/modules/common-transformer-stream/src/main/scala/com/snowplowanalytics/snowplow/rdbloader/transformer/stream/common/Config.scala
@@ -182,7 +182,11 @@ object Config {
   object QueueConfig {
     final case class SNS(topicArn: String, region: Region) extends QueueConfig
 
-    final case class SQS(queueName: String, region: Region, messageGroupId: Option[String] = None) extends QueueConfig
+    final case class SQS(
+      queueName: String,
+      region: Region,
+      messageGroupId: Option[String] = None
+    ) extends QueueConfig
 
     final case class Pubsub(
       topic: String,


### PR DESCRIPTION
## Summary
- run scalafmt on `Config.scala`

## Testing
- `scalafmt --test` on `Config.scala`
- ❌ `sbt test` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ff86e50d8832e91c8ef31696e580e